### PR TITLE
feat(teams): add endpoint to get player teams with tournament info

### DIFF
--- a/PLAYER_TEAMS_API.md
+++ b/PLAYER_TEAMS_API.md
@@ -1,0 +1,126 @@
+# API de Equipos del Jugador
+
+## Endpoint: Obtener mis equipos
+
+### Descripción
+Este endpoint permite a un usuario autenticado obtener todos los equipos que ha creado (donde es capitán), junto con la información del torneo al que cada equipo está inscrito.
+
+### Endpoint
+```
+GET /player/teams
+```
+
+### Autenticación
+- **Requerida**: Sí
+- **Tipo**: JWT Bearer Token
+- **Roles**: Cualquier usuario autenticado (PLAYER u ORGANIZER)
+
+### Headers
+```
+Authorization: Bearer <jwt_token>
+```
+
+### Respuesta Exitosa (200 OK)
+
+```json
+[
+  {
+    "teamId": "equipo-123",
+    "teamName": "Los Titanes de Chiapas",
+    "teamLogo": "url-del-logo.png",
+    "tournament": {
+      "tournamentId": "torneo-abc",
+      "tournamentName": "Torneo Relámpago de Fútbol"
+    }
+  },
+  {
+    "teamId": "equipo-456",
+    "teamName": "Otro Equipo Genial",
+    "teamLogo": "url-de-otro-logo.png",
+    "tournament": {
+      "tournamentId": "torneo-xyz",
+      "tournamentName": "Copa de Verano de Voleibol"
+    }
+  }
+]
+```
+
+### Campos de Respuesta
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `teamId` | string | ID único del equipo |
+| `teamName` | string | Nombre del equipo |
+| `teamLogo` | string | URL del logo del equipo (opcional) |
+| `tournament.tournamentId` | string | ID único del torneo |
+| `tournament.tournamentName` | string | Nombre del torneo |
+
+### Respuestas de Error
+
+#### 401 Unauthorized
+```json
+{
+  "statusCode": 401,
+  "message": "Unauthorized"
+}
+```
+
+#### 500 Internal Server Error
+```json
+{
+  "statusCode": 500,
+  "message": "Internal server error"
+}
+```
+
+### Ejemplo de Uso
+
+#### cURL
+```bash
+curl -X GET http://localhost:3000/player/teams \
+  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+```
+
+#### JavaScript (Fetch)
+```javascript
+const response = await fetch('http://localhost:3000/player/teams', {
+  method: 'GET',
+  headers: {
+    'Authorization': 'Bearer ' + token,
+    'Content-Type': 'application/json'
+  }
+});
+
+const teams = await response.json();
+console.log(teams);
+```
+
+### Lógica de Funcionamiento
+
+1. **Autenticación**: El endpoint verifica que el usuario esté autenticado mediante JWT
+2. **Búsqueda de Equipos**: Busca todos los equipos donde el usuario es capitán
+3. **Obtención de Inscripciones**: Para cada equipo, obtiene todas las inscripciones a torneos
+4. **Mapeo de Datos**: Crea una respuesta que incluye información del equipo y del torneo para cada inscripción
+5. **Respuesta**: Retorna un array con todos los equipos y sus respectivos torneos
+
+### Casos Especiales
+
+- Si un equipo está inscrito en múltiples torneos, aparecerá una entrada por cada torneo
+- Si un equipo no está inscrito en ningún torneo, no aparecerá en la respuesta
+- Solo se muestran equipos donde el usuario es capitán (creador del equipo)
+- Si el usuario no ha creado ningún equipo, se retorna un array vacío
+
+### Notas Técnicas
+
+- **Controlador**: `PlayerController.getMyTeams()`
+- **Servicio**: `TeamsService.findTeamsByPlayer()`
+- **DTO**: `PlayerTeamsResponseDto`
+- **Relaciones**: Utiliza relaciones de TypeORM para optimizar consultas
+- **Performance**: Consulta eficiente que carga equipos con sus inscripciones y torneos en una sola query
+
+### Seguridad
+
+- Requiere autenticación JWT válida
+- Solo muestra equipos creados por el usuario autenticado
+- No expone información sensible de otros usuarios
+- Utiliza guards de autenticación de NestJS

--- a/src/teams/dto/player-teams-response.dto.ts
+++ b/src/teams/dto/player-teams-response.dto.ts
@@ -1,0 +1,9 @@
+export class PlayerTeamsResponseDto {
+  teamId: string;
+  teamName: string;
+  teamLogo?: string;
+  tournament: {
+    tournamentId: string;
+    tournamentName: string;
+  };
+}

--- a/src/teams/teams.module.ts
+++ b/src/teams/teams.module.ts
@@ -10,6 +10,7 @@ import { User } from 'src/auth/entities/user.entity';
 @Module({
   controllers: [TeamsController],
   providers: [TeamsService],
+  exports: [TeamsService],
   imports: [
     TypeOrmModule.forFeature([Team, TeamMember, User]), 
     AuthModule,

--- a/src/tournaments/player.controller.ts
+++ b/src/tournaments/player.controller.ts
@@ -3,10 +3,14 @@ import { TournamentsService } from './tournaments.service';
 import { AuthGuard } from '@nestjs/passport';
 import { GetUser } from 'src/auth/decorators/get-user.decorator';
 import { User } from 'src/auth/entities/user.entity';
+import { TeamsService } from 'src/teams/teams.service';
 
 @Controller('player')
 export class PlayerController {
-  constructor(private readonly tournamentsService: TournamentsService) {}
+  constructor(
+    private readonly tournamentsService: TournamentsService,
+    private readonly teamsService: TeamsService,
+  ) {}
 
   /**
    * Obtiene todos los torneos en los que está inscrito el usuario autenticado
@@ -16,5 +20,15 @@ export class PlayerController {
   @UseGuards(AuthGuard('jwt'))
   getMyTournaments(@GetUser() user: User) {
     return this.tournamentsService.findTournamentsByPlayer(user);
+  }
+
+  /**
+   * Obtiene todos los equipos creados por el usuario autenticado con información del torneo
+   * GET /player/teams
+   */
+  @Get('teams')
+  @UseGuards(AuthGuard('jwt'))
+  getMyTeams(@GetUser() user: User) {
+    return this.teamsService.findTeamsByPlayer(user);
   }
 }

--- a/src/tournaments/tournaments.module.ts
+++ b/src/tournaments/tournaments.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from 'src/auth/auth.module';
 import { TournamentInscription } from './entities/tournament-inscription.entity';
 import { Team } from 'src/teams/entities/team.entity';
 import { Match } from 'src/matches/entities/match.entity';
+import { TeamsModule } from 'src/teams/teams.module';
 
 @Module({
   controllers: [TournamentsController, OrganizerController, PlayerController],
@@ -16,6 +17,7 @@ import { Match } from 'src/matches/entities/match.entity';
   imports: [
     TypeOrmModule.forFeature([Tournament, TournamentInscription, Team, Match]),
     AuthModule,
+    TeamsModule,
   ],
 })
 export class TournamentsModule {}


### PR DESCRIPTION
Add new endpoint GET /player/teams that returns all teams where the user is captain along with tournament information. Includes:
- New PlayerTeamsResponseDto
- TeamsService method to fetch teams with tournament data
- Updated TeamsModule exports and TournamentsModule imports
- Comprehensive API documentation